### PR TITLE
Replaced clip_skip function with set_clip_options

### DIFF
--- a/adv_encode.py
+++ b/adv_encode.py
@@ -223,7 +223,7 @@ def encode_token_weights_l(model, token_weight_pairs):
 
 def encode_token_weights(model, token_weight_pairs, encode_func):
     if model.layer_idx is not None:
-        model.cond_stage_model.clip_layer(model.layer_idx)
+        model.cond_stage_model.set_clip_options({"layer": model.layer_idx})
     
     model_management.load_model_gpu(model.patcher)
     return encode_func(model.cond_stage_model, token_weight_pairs)


### PR DESCRIPTION
# Problem

There is no `clip_skip` function in the new ComfyUI, instead it is now `set_clip_options`  
Already created issue: Closes https://github.com/BlenderNeko/ComfyUI_Cutoff/issues/24

# Solution

I changed the line with the function call, everything started working without errors.